### PR TITLE
Use cmake -e copy with file destination

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,8 +15,9 @@ yarp_install(FILES ${scripts}  DESTINATION ${ICUBCONTRIB_APPLICATIONS_TEMPLATES_
 
 add_custom_target(copy_lua_in_build ALL)
 foreach(_bin IN ITEMS ${lua_bin})
+  get_filename_component(_bin_name ${_bin} NAME)
   add_custom_command(TARGET copy_lua_in_build POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy ${_bin} ${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}
-                     COMMENT "Copying ${_bin} to ${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}/")
+                     COMMAND ${CMAKE_COMMAND} -E copy ${_bin} ${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}/${_bin_name}
+                     COMMENT "Copying ${_bin} to ${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}/${_bin_name}")
 endforeach()
 install(PROGRAMS ${lua_bin} DESTINATION bin)


### PR DESCRIPTION
For some reason, the use of cmake -e copy using as destination a directory is creating a Visual Studio error MSB3191, see https://github.com/robotology/funny-things/issues/13 .
Apparently switching to explicity use the destination file name instead of a directory is able to avoid this issue.

Fix https://github.com/robotology/funny-things/issues/13 . 
