### PR TITLE
Upgrade lua scripts to yarp-3.5

### DIFF
--- a/app/conf/icub-look_pm.lua
+++ b/app/conf/icub-look_pm.lua
@@ -45,8 +45,8 @@ end
 PortMonitor.update = function(thing)
     
     bt = thing:asBottle()
-    u = bt:get(0):asInt()
-    v = bt:get(1):asInt()
+    u = bt:get(0):asInt32()
+    v = bt:get(1):asInt32()
     bt:clear()
     bt:addString("left")
     bt:addInt(u)

--- a/app/conf/r1-look_pm.lua
+++ b/app/conf/r1-look_pm.lua
@@ -47,8 +47,8 @@ PortMonitor.update = function(thing)
     
     bt = thing:asBottle()
     
-    px = bt:get(0):asInt()
-    py = bt:get(1):asInt()
+    px = bt:get(0):asInt32()
+    py = bt:get(1):asInt32()
     
     local tx = yarp.Property()
     th = yarp.Things()

--- a/app/scripts/lua/gaze.lua
+++ b/app/scripts/lua/gaze.lua
@@ -82,25 +82,25 @@ while state ~= "quit" and not interrupting do
 
             if state == "look" then
 
-                azi = cmd:get(1):asDouble()
-                ele = cmd:get(2):asDouble()
-                ver = cmd:get(3):asDouble()
+                azi = cmd:get(1):asFloat64()
+                ele = cmd:get(2):asFloat64()
+                ver = cmd:get(3):asFloat64()
                 print("received: look ", azi,ele,ver)
 
             elseif state == "look-around" then
 
                 if cmd:size()>1 then
 
-                    azi = cmd:get(1):asDouble()
-                    ele = cmd:get(2):asDouble()
-                    ver = cmd:get(3):asDouble()
+                    azi = cmd:get(1):asFloat64()
+                    ele = cmd:get(2):asFloat64()
+                    ver = cmd:get(3):asFloat64()
 
                 else
 
                     local fp = port_gaze_rx:read(true)
-                    azi = fp:get(0):asDouble()
-                    ele = fp:get(1):asDouble()
-                    ver = fp:get(2):asDouble()
+                    azi = fp:get(0):asFloat64()
+                    ele = fp:get(1):asFloat64()
+                    ver = fp:get(2):asFloat64()
 
                 end
                 print("received: look around ", azi,ele,ver)
@@ -109,9 +109,9 @@ while state ~= "quit" and not interrupting do
 
         elseif cmd_rx == "set-delta" then
 
-            azi_delta = cmd:get(1):asDouble()
-            ele_delta = cmd:get(2):asDouble()
-            ver_delta = cmd:get(3):asDouble()
+            azi_delta = cmd:get(1):asFloat64()
+            ele_delta = cmd:get(2):asFloat64()
+            ver_delta = cmd:get(3):asFloat64()
             print("received: set delta ", azi_delta,ele_delta,ver_delta)
 
         else
@@ -124,9 +124,9 @@ while state ~= "quit" and not interrupting do
     if state == "init" then
 
         local fp = port_gaze_rx:read(true)
-        azi = fp:get(0):asDouble()
-        ele = fp:get(1):asDouble()
-        ver = fp:get(2):asDouble()
+        azi = fp:get(0):asFloat64()
+        ele = fp:get(1):asFloat64()
+        ver = fp:get(2):asFloat64()
         state = "look-around"
 
     elseif state == "look" then

--- a/app/scripts/lua/look-pixel.lua
+++ b/app/scripts/lua/look-pixel.lua
@@ -36,8 +36,8 @@ port_rx:open("/look-pixel/rx")
 while not interrupting do
     local pixel = port_rx:read(false)
     if pixel ~= nil then
-        local u = pixel:get(0):asInt()
-        local v = pixel:get(1):asInt()
+        local u = pixel:get(0):asInt32()
+        local v = pixel:get(1):asInt32()
 
         local cmd = port_tx:prepare()
         cmd:clear()


### PR DESCRIPTION
This PR follows up on https://github.com/robotology/funny-things/commit/d020e54902f3907d88ed837a839504e85501ac18 by applying replacing deprecated `asInt()` and `asDouble()` methods with `asInt32()` and `asFloat64()`, respectively, as dictated from `yarp-3.5` onward.

cc @traversaro 