### PR TITLE
Remove deprecated addDouble in favour of addFloat64

### DIFF
--- a/app/scripts/lua/look-pixel.lua
+++ b/app/scripts/lua/look-pixel.lua
@@ -42,9 +42,9 @@ while not interrupting do
         local cmd = port_tx:prepare()
         cmd:clear()
         cmd:addString("left")
-        cmd:addDouble(u)
-        cmd:addDouble(v)
-        cmd:addDouble(1.0)
+        cmd:addFloat64(u)
+        cmd:addFloat64(v)
+        cmd:addFloat64(1.0)
         port_tx:write()
         print("looking at ", u,v)
     end


### PR DESCRIPTION
Together with @MSECode we noticed that the `look-pixel.lua` script uses `addDouble` that was deprecated in yarp v3.5. 

cc @Nicogene 